### PR TITLE
fix bug blocking >256 candidates

### DIFF
--- a/pyrankvote/models.py
+++ b/pyrankvote/models.py
@@ -55,7 +55,7 @@ class Ballot:
 
     @staticmethod
     def _is_duplicates(ranked_candidates) -> bool:
-        return len(set(ranked_candidates)) is not len(ranked_candidates)
+        return len(set(ranked_candidates)) != len(ranked_candidates)
 
     @staticmethod
     def _is_all_candidate_objects(objects) -> bool:


### PR DESCRIPTION
Fixes a bug blocking elections with greater than 256 candidates. The check by `Ballot._is_duplicates()` to see if there are duplicated candidates on the ballot uses `is not` instead of `!=`.

The trouble is that in Python, `is` compares object identity. Integers in the interval `[-5, 256] ` are singleton objects, and numbers outside that range are not. 

```python
a = 10
b = 10
a is b
# True

x = 257
y = 257
x is y 
# False
```