### PR TITLE
Fixed STV Droop-Quota

### DIFF
--- a/pyrankvote/multiple_seat_ranking_methods.py
+++ b/pyrankvote/multiple_seat_ranking_methods.py
@@ -157,7 +157,7 @@ def single_transferable_vote(
     election_results = ElectionResults()
 
     voters, seats = manager.get_number_of_non_exhausted_ballots(), number_of_seats
-    votes_needed_to_win: float = voters / float((seats + 1))  # Drop quota
+    votes_needed_to_win: float = round((voters / (seats + 1))+1)  # Editied droop quota
 
     # Remove worst candidate until same number of candidates left as electable
     # While it is more candidates left than electable


### PR DESCRIPTION
After running a simulation, I noticed that the elected candidates were being elected with partial votes like 30.33. Small fix to conform to the correct droop-quota as listed in Wikipedia.

![image](https://user-images.githubusercontent.com/61350902/191026249-9decd667-b766-456c-804c-5b919b931050.png)

However, there are still issues with other candidates having decimal votes while the elected candidate does not.